### PR TITLE
feat(release): Replace release bot with GH app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_RELEASE_PAT }}
+          token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
The `getsentry-release` is a GitHub bot account that is used in various automation, and the `${{ secrets.GH_RELEASE_PAT }}` is a personal access token from that bot account. We are using a regular GitHub account as a bot while it should be a non-human account since there are no humans behind it. Hence, we are replacing it with a GitHub App. 

Functionality wise, there will be no difference. 

More details: https://www.notion.so/sentry/DACI-Replace-GitHub-bot-accounts-with-GitHub-Apps-getsentry-release-15109965d1204a91b9be71c49e8b66e0?pvs=4

#skip-changelog